### PR TITLE
updated crd to match type def

### DIFF
--- a/crd/cluster-registry.yaml
+++ b/crd/cluster-registry.yaml
@@ -15,41 +15,43 @@ spec:
       properties:
         spec:
           type: object
-          kubernetesAPIEndpoints:
-            type: object
-            properties:
-            serverEndpoints:
-              type: array
-              items:
-                type: object
-                properties:
-                  clientCIDR:
-                    type: string
-                  serverAddress:
-                    type: string
+          properties:
+            kubernetesAPIEndpoints:
+              type: object
+              properties:
+                serverEndpoints:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      clientCIDR:
+                        type: string
+                        pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
+                      serverAddress:
+                        type: string
             caBundle:
-              type: byte
-          authInfo:
-            type: object
-            properties:
-            providers:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  type:
+                type: byte
+            authInfo:
+              type: object
+              properties:
+                providers:
+                  type: array
+                  items:
                     type: object
                     properties:
                       name:
                         type: string
-                  config:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          type: string
-                        value:
-                          type: string
+                      type:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                      config:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            value:
+                              type: string

--- a/crd/cluster-registry.yaml
+++ b/crd/cluster-registry.yaml
@@ -25,9 +25,13 @@ spec:
                 properties:
                   clientCIDR:
                     type: string
+                  serverAddress:
+                    type: string
             caBundle:
               type: byte
           authInfo:
+            type: object
+            properties:
             providers:
               type: array
               items:


### PR DESCRIPTION
I noticed that some fields were missing from the cluster-registry-crd.yaml when compared with the typedef 
ex. serverAddress.
I am unsure if this was an oversight or if serverAddress was left out intentionally.